### PR TITLE
support building `QobjEvo` objects

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -21,13 +21,11 @@ QuantumToolbox = "6c2fb7c5-b903-41d2-bc5e-5a7c320b9fab"
 PQOQuantumToolboxExt = ["QuantumToolbox"]
 
 [compat]
-DirectTrajOpt = "0.2"
 ExponentialAction = "0.2"
 ForwardDiff = "0.10, 1.0"
 LinearAlgebra = "1.10, 1.11"
 NamedTrajectories = "0.3"
 ProgressMeter = "1.10"
-QuantumCollocation = "0.7"
 Reexport = "1.2"
 SparseArrays = "1.10, 1.11"
 TestItemRunner = "1.1"
@@ -35,10 +33,8 @@ TestItems = "1.0"
 julia = "1.10, 1.11"
 
 [extras]
-DirectTrajOpt = "c823fa1f-8872-4af5-b810-2b9b72bbbf56"
 QuantumToolbox = "6c2fb7c5-b903-41d2-bc5e-5a7c320b9fab"
-QuantumCollocation = "0dc23a59-5ffb-49af-b6bd-932a8ae77adf"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["DirectTrajOpt", "QuantumCollocation", "QuantumToolbox", "Test"]
+test = ["QuantumToolbox", "Test"]

--- a/Project.toml
+++ b/Project.toml
@@ -15,33 +15,30 @@ TestItemRunner = "f8b46487-2199-4994-9208-9a1283c18c0a"
 TestItems = "1c621080-faea-4a02-84b6-bbd5e436b8fe"
 
 [weakdeps]
-Interpolations = "a98d9a8b-a2ab-59e6-89dd-64a1c18fca59"
 QuantumToolbox = "6c2fb7c5-b903-41d2-bc5e-5a7c320b9fab"
 
 [extensions]
-PQOQuantumToolboxExt = ["Interpolations", "QuantumToolbox"]
+PQOQuantumToolboxExt = ["QuantumToolbox"]
 
 [compat]
-DirectTrajOpt = "0.2.3"
+DirectTrajOpt = "0.2"
 ExponentialAction = "0.2"
 ForwardDiff = "0.10, 1.0"
-Interpolations = "0.15"
 LinearAlgebra = "1.10, 1.11"
 NamedTrajectories = "0.3"
 ProgressMeter = "1.10"
+QuantumCollocation = "0.7"
 Reexport = "1.2"
 SparseArrays = "1.10, 1.11"
-QuantumCollocation = "0.7.2"
 TestItemRunner = "1.1"
 TestItems = "1.0"
 julia = "1.10, 1.11"
 
 [extras]
 DirectTrajOpt = "c823fa1f-8872-4af5-b810-2b9b72bbbf56"
-Interpolations = "a98d9a8b-a2ab-59e6-89dd-64a1c18fca59"
 QuantumToolbox = "6c2fb7c5-b903-41d2-bc5e-5a7c320b9fab"
 QuantumCollocation = "0dc23a59-5ffb-49af-b6bd-932a8ae77adf"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["DirectTrajOpt", "Interpolations", "QuantumToolbox",  "QuantumCollocation", "Test"]
+test = ["DirectTrajOpt", "QuantumCollocation", "QuantumToolbox", "Test"]

--- a/Project.toml
+++ b/Project.toml
@@ -14,12 +14,21 @@ SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 TestItemRunner = "f8b46487-2199-4994-9208-9a1283c18c0a"
 TestItems = "1c621080-faea-4a02-84b6-bbd5e436b8fe"
 
+[weakdeps]
+Interpolations = "a98d9a8b-a2ab-59e6-89dd-64a1c18fca59"
+QuantumToolbox = "6c2fb7c5-b903-41d2-bc5e-5a7c320b9fab"
+
+[extensions]
+PQOQuantumToolboxExt = ["Interpolations", "QuantumToolbox"]
+
 [compat]
 ExponentialAction = "0.2"
 ForwardDiff = "0.10, 1.0"
+Interpolations = "0.16.1"
 LinearAlgebra = "1.10, 1.11"
 NamedTrajectories = "0.3"
 ProgressMeter = "1.10"
+QuantumToolbox = "0.31.1"
 Reexport = "1.2"
 SparseArrays = "1.10, 1.11"
 TestItemRunner = "1.1"
@@ -27,7 +36,9 @@ TestItems = "1.0"
 julia = "1.10, 1.11"
 
 [extras]
+Interpolations = "a98d9a8b-a2ab-59e6-89dd-64a1c18fca59"
+QuantumToolbox = "6c2fb7c5-b903-41d2-bc5e-5a7c320b9fab"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test"]
+test = ["Interpolations", "QuantumToolbox", "Test"]

--- a/Project.toml
+++ b/Project.toml
@@ -36,9 +36,11 @@ TestItems = "1.0"
 julia = "1.10, 1.11"
 
 [extras]
+DirectTrajOpt = "c823fa1f-8872-4af5-b810-2b9b72bbbf56"
 Interpolations = "a98d9a8b-a2ab-59e6-89dd-64a1c18fca59"
+QuantumCollocation = "0dc23a59-5ffb-49af-b6bd-932a8ae77adf"
 QuantumToolbox = "6c2fb7c5-b903-41d2-bc5e-5a7c320b9fab"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Interpolations", "QuantumToolbox", "Test"]
+test = ["DirectTrajOpt", "Interpolations", "QuantumToolbox", "QuantumCollocation", "Test"]

--- a/Project.toml
+++ b/Project.toml
@@ -22,15 +22,16 @@ QuantumToolbox = "6c2fb7c5-b903-41d2-bc5e-5a7c320b9fab"
 PQOQuantumToolboxExt = ["Interpolations", "QuantumToolbox"]
 
 [compat]
+DirectTrajOpt = "0.2.3"
 ExponentialAction = "0.2"
 ForwardDiff = "0.10, 1.0"
-Interpolations = "0.16.1"
+Interpolations = "0.15"
 LinearAlgebra = "1.10, 1.11"
 NamedTrajectories = "0.3"
 ProgressMeter = "1.10"
-QuantumToolbox = "0.31.1"
 Reexport = "1.2"
 SparseArrays = "1.10, 1.11"
+QuantumCollocation = "0.7.2"
 TestItemRunner = "1.1"
 TestItems = "1.0"
 julia = "1.10, 1.11"
@@ -38,9 +39,9 @@ julia = "1.10, 1.11"
 [extras]
 DirectTrajOpt = "c823fa1f-8872-4af5-b810-2b9b72bbbf56"
 Interpolations = "a98d9a8b-a2ab-59e6-89dd-64a1c18fca59"
-QuantumCollocation = "0dc23a59-5ffb-49af-b6bd-932a8ae77adf"
 QuantumToolbox = "6c2fb7c5-b903-41d2-bc5e-5a7c320b9fab"
+QuantumCollocation = "0dc23a59-5ffb-49af-b6bd-932a8ae77adf"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["DirectTrajOpt", "Interpolations", "QuantumToolbox", "QuantumCollocation", "Test"]
+test = ["DirectTrajOpt", "Interpolations", "QuantumToolbox",  "QuantumCollocation", "Test"]

--- a/ext/PQOQuantumToolboxExt.jl
+++ b/ext/PQOQuantumToolboxExt.jl
@@ -41,5 +41,4 @@ function QuantumToolbox.QobjEvo(sys::QuantumSystem, traj::NamedTrajectory)
     end
     return QuantumToolbox.QuantumObjectEvolution(Tuple(qobj_evo_components))
 end
-
 end

--- a/ext/PQOQuantumToolboxExt.jl
+++ b/ext/PQOQuantumToolboxExt.jl
@@ -4,7 +4,7 @@ using QuantumToolbox
 import QuantumToolbox: QobjEvo
 using PiccoloQuantumObjects
 using NamedTrajectories
-import LinearAlgebra
+using LinearAlgebra
 
 function _zoh(times::AbstractVector{<:Real}, amps::AbstractVector{<:Number})
     isempty(times) && throw(ArgumentError("Time points cannot be empty"))

--- a/ext/PQOQuantumToolboxExt.jl
+++ b/ext/PQOQuantumToolboxExt.jl
@@ -1,11 +1,11 @@
 module PQOQuantumToolboxExt
 
 using QuantumToolbox
-import QuantumToolbox: Qobj, length, size, QuantumObjectEvolution
+import QuantumToolbox: Qobj, length, size, QuantumObjectEvolution, QobjEvo
 import PiccoloQuantumObjects
-import PiccoloQuantumObjects: get_drift, get_drives, QobjEvo
+import PiccoloQuantumObjects: get_drift, get_drives, QuantumSystem
 import NamedTrajectories
-import NamedTrajectories: get_times
+import NamedTrajectories: get_times, NamedTrajectory
 import Interpolations
 import Interpolations: LinearInterpolation
 import LinearAlgebra
@@ -23,7 +23,7 @@ and ``a_j(t)`` are the time-dependent control amplitudes for each drive, obtaine
 The time-dependent coefficient functions for `QobjEvo` are constructed by *linearly interpolating* the
 control amplitudes from `traj.a` across the `get_times(traj)` time points using `Interpolations.jl`.
 """
-function PiccoloQuantumObjects.QobjEvo(sys::QuantumSystem, traj::NamedTrajectory)
+function QuantumToolbox.QobjEvo(sys::QuantumSystem, traj::NamedTrajectory)
     H_drift_matrix = get_drift(sys)
     H_drives_matrices = get_drives(sys)
     H0_qobj = Qobj(H_drift_matrix)

--- a/ext/PQOQuantumToolboxExt.jl
+++ b/ext/PQOQuantumToolboxExt.jl
@@ -3,7 +3,7 @@ module PQOQuantumToolboxExt
 using QuantumToolbox
 import QuantumToolbox: QobjEvo
 using PiccoloQuantumObjects
-using NamedTrajectories: get_times
+using NamedTrajectories
 import LinearAlgebra
 
 function _zoh(times::AbstractVector{<:Real}, amps::AbstractVector{<:Number})
@@ -12,25 +12,45 @@ function _zoh(times::AbstractVector{<:Real}, amps::AbstractVector{<:Number})
     return (_, t) -> amps[clamp(searchsortedlast(times, t), 1, length(times))]
 end
 
+"""Internal function to construct the Hamiltonian part of a `QobjEvo` from a system and trajectory."""
+function _construct_hamiltonian_evolution(sys::Union{QuantumSystem,OpenQuantumSystem}, traj::NamedTrajectory)
+    H0 = Qobj(get_drift(sys))
+    H_drives = Qobj.(get_drives(sys))
+    times = get_times(traj)
+    amps_mat = traj.a
+    n_controls = size(amps_mat, 1)
+    @assert n_controls == length(H_drives) "Number of controls in trajectory ($n_controls) doesn't match number of drive Hamiltonians ($(length(H_drives)))"
+    comps = Any[H0]
+    for j in 1:n_controls
+        push!(comps, (H_drives[j], _zoh(times, @view amps_mat[j, :])))
+    end
+    return Tuple(comps)
+end
+
 """
     QobjEvo(sys::QuantumSystem, traj::NamedTrajectory)
 
-Converts a QuantumSystem and a NamedTrajectory into a QobjEvo object using zero-order hold.
+Converts a `QuantumSystem` and a `NamedTrajectory` into a `QobjEvo` object using zero-order hold.
 
 The time-dependent Hamiltonian is constructed as `\\hat{H}(t) = \\hat{H}_0 + \\sum_j a_j(t) \\hat{H}_j,
 where `\\hat{H}_0 is the drift Hamiltonian, \\hat{H}_j are the drive Hamiltonians, and a_j(t) are
 the control amplitudes from traj.a."""
 function QuantumToolbox.QobjEvo(sys::QuantumSystem, traj::NamedTrajectory)
-    H0 = Qobj(get_drift(sys))
-    H_drives = Qobj.(get_drives(sys))
-    times = get_times(traj)
-    amps_mat = traj.a
-    comps = Any[H0]
-    n_controls = size(amps_mat, 1)
-    for j in 1:n_controls
-        push!(comps, (H_drives[j], _zoh(times, @view amps_mat[j, :])))
-    end
-    return QuantumToolbox.QuantumObjectEvolution(Tuple(comps))
+    comps = _construct_hamiltonian_evolution(sys, traj)
+    return QuantumToolbox.QuantumObjectEvolution(comps)
+end
+
+"""
+    QObjEvo(sys::OpenQuantumSystem, traj::NamedTrajectory)
+
+Converts an `OpenQuantumSystem` and `NamedTrajectory` into:
+- A `QObjEvo` for the Hamiltonian part (same as QuantumSystem version)
+- A vector of `Qobj` dissipation operators
+"""
+function QuantumToolbox.QobjEvo(sys::OpenQuantumSystem, traj::NamedTrajectory)
+    comps = _construct_hamiltonian_evolution(sys, traj)
+    c_ops = Qobj.(sys.dissipation_operators)
+    return QuantumToolbox.QuantumObjectEvolution(comps), c_ops
 end
 
 end

--- a/ext/PQOQuantumToolboxExt.jl
+++ b/ext/PQOQuantumToolboxExt.jl
@@ -1,0 +1,45 @@
+module PQOQuantumToolboxExt
+
+using QuantumToolbox
+import QuantumToolbox: Qobj, length, size, QuantumObjectEvolution
+import PiccolouantumObjects
+import PiccolouantumObjects: get_drift, get_drives, QobjEvo
+import NamedTrajectories
+import NamedTrajectories: get_times
+import Interpolations
+import Interpolations: LinearInterpolation
+import LinearAlgebra
+
+"""
+    QobjEvo(sys::QuantumSystem, traj::NamedTrajectory) -> QuantumToolbox.QuantumObjectEvolution
+
+Converts a `QuantumSystem` and a `NamedTrajectory` into a `QobjEvo` object for a closed quantum system.
+
+We extend the `QuantumToolbox.QuantumObjectEvolution` constructor to directly take `Piccolo.jl`
+objects by constructing the time-dependent Hamiltonian ``\\hat{H}(t) = \\hat{H}_0 + \\sum_j a_j(t) \\hat{H}_j``,
+where ``\\hat{H}_0`` is the drift Hamiltonian from `sys`, ``\\hat{H}_j`` are the drive Hamiltonians from `sys`,
+and ``a_j(t)`` are the time-dependent control amplitudes for each drive, obtained from `traj.a`.
+
+The time-dependent coefficient functions for `QobjEvo` are constructed by *linearly interpolating* the
+control amplitudes from `traj.a` across the `get_times(traj)` time points using `Interpolations.jl`.
+"""
+function PiccoloQuantumObjects.QobjEvo(sys::QuantumSystem, traj::NamedTrajectory)
+    H_drift_matrix = get_drift(sys)
+    H_drives_matrices = get_drives(sys)
+    H0_qobj = Qobj(H_drift_matrix)
+    Hj_qobjs = [Qobj(Hj) for Hj in H_drives_matrices]
+    times = get_times(traj)
+    control_amplitudes_data = traj.a
+    num_drives_sys = length(Hj_qobjs)
+    num_drives_traj = size(control_amplitudes_data, 1)
+    qobj_evo_components = Vector{Any}(undef, num_drives_sys + 1)
+    qobj_evo_components[1] = H0_qobj
+    for j in 1:num_drives_sys
+        itp = LinearInterpolation(times, control_amplitudes_data[j, :], extrapolation_bc=Interpolations.Flat())
+        coef_func = (p, t) -> itp(t)
+        qobj_evo_components[j+1] = (Hj_qobjs[j], coef_func)
+    end
+    return QuantumToolbox.QuantumObjectEvolution(Tuple(qobj_evo_components))
+end
+
+end

--- a/ext/PQOQuantumToolboxExt.jl
+++ b/ext/PQOQuantumToolboxExt.jl
@@ -2,8 +2,8 @@ module PQOQuantumToolboxExt
 
 using QuantumToolbox
 import QuantumToolbox: Qobj, length, size, QuantumObjectEvolution
-import PiccolouantumObjects
-import PiccolouantumObjects: get_drift, get_drives, QobjEvo
+import PiccoloQuantumObjects
+import PiccoloQuantumObjects: get_drift, get_drives, QobjEvo
 import NamedTrajectories
 import NamedTrajectories: get_times
 import Interpolations

--- a/ext/PQOQuantumToolboxExt.jl
+++ b/ext/PQOQuantumToolboxExt.jl
@@ -1,44 +1,36 @@
 module PQOQuantumToolboxExt
 
 using QuantumToolbox
-import QuantumToolbox: Qobj, length, size, QuantumObjectEvolution, QobjEvo
-import PiccoloQuantumObjects
-import PiccoloQuantumObjects: get_drift, get_drives, QuantumSystem
-import NamedTrajectories
-import NamedTrajectories: get_times, NamedTrajectory
-import Interpolations
-import Interpolations: LinearInterpolation
+import QuantumToolbox: QobjEvo
+using PiccoloQuantumObjects
+using NamedTrajectories: get_times
 import LinearAlgebra
 
-"""
-    QobjEvo(sys::QuantumSystem, traj::NamedTrajectory) -> QuantumToolbox.QuantumObjectEvolution
-
-Converts a `QuantumSystem` and a `NamedTrajectory` into a `QobjEvo` object for a closed quantum system.
-
-We extend the `QuantumToolbox.QuantumObjectEvolution` constructor to directly take `Piccolo.jl`
-objects by constructing the time-dependent Hamiltonian ``\\hat{H}(t) = \\hat{H}_0 + \\sum_j a_j(t) \\hat{H}_j``,
-where ``\\hat{H}_0`` is the drift Hamiltonian from `sys`, ``\\hat{H}_j`` are the drive Hamiltonians from `sys`,
-and ``a_j(t)`` are the time-dependent control amplitudes for each drive, obtained from `traj.a`.
-
-The time-dependent coefficient functions for `QobjEvo` are constructed by *linearly interpolating* the
-control amplitudes from `traj.a` across the `get_times(traj)` time points using `Interpolations.jl`.
-"""
-function QuantumToolbox.QobjEvo(sys::QuantumSystem, traj::NamedTrajectory)
-    H_drift_matrix = get_drift(sys)
-    H_drives_matrices = get_drives(sys)
-    H0_qobj = Qobj(H_drift_matrix)
-    Hj_qobjs = [Qobj(Hj) for Hj in H_drives_matrices]
-    times = get_times(traj)
-    control_amplitudes_data = traj.a
-    num_drives_sys = length(Hj_qobjs)
-    num_drives_traj = size(control_amplitudes_data, 1)
-    qobj_evo_components = Vector{Any}(undef, num_drives_sys + 1)
-    qobj_evo_components[1] = H0_qobj
-    for j in 1:num_drives_sys
-        itp = LinearInterpolation(times, control_amplitudes_data[j, :], extrapolation_bc=Interpolations.Flat())
-        coef_func = (p, t) -> itp(t)
-        qobj_evo_components[j+1] = (Hj_qobjs[j], coef_func)
-    end
-    return QuantumToolbox.QuantumObjectEvolution(Tuple(qobj_evo_components))
+function _zoh(times::AbstractVector{<:Real}, amps::AbstractVector{<:Number})
+    isempty(times) && throw(ArgumentError("Time points cannot be empty"))
+    length(times) != length(amps) && throw(DimensionMismatch("Times and amplitudes must have same length"))
+    return (_, t) -> amps[clamp(searchsortedlast(times, t), 1, length(times))]
 end
+
+"""
+    QobjEvo(sys::QuantumSystem, traj::NamedTrajectory)
+
+Converts a QuantumSystem and a NamedTrajectory into a QobjEvo object using zero-order hold.
+
+The time-dependent Hamiltonian is constructed as `\\hat{H}(t) = \\hat{H}_0 + \\sum_j a_j(t) \\hat{H}_j,
+where `\\hat{H}_0 is the drift Hamiltonian, \\hat{H}_j are the drive Hamiltonians, and a_j(t) are
+the control amplitudes from traj.a."""
+function QuantumToolbox.QobjEvo(sys::QuantumSystem, traj::NamedTrajectory)
+    H0 = Qobj(get_drift(sys))
+    H_drives = Qobj.(get_drives(sys))
+    times = get_times(traj)
+    amps_mat = traj.a
+    comps = Any[H0]
+    n_controls = size(amps_mat, 1)
+    for j in 1:n_controls
+        push!(comps, (H_drives[j], _zoh(times, @view amps_mat[j, :])))
+    end
+    return QuantumToolbox.QuantumObjectEvolution(Tuple(comps))
+end
+
 end

--- a/src/quantum_object_utils.jl
+++ b/src/quantum_object_utils.jl
@@ -15,8 +15,6 @@ using ..Gates
 using LinearAlgebra
 using TestItems
 
-function QobjEvo end
-
 @doc raw"""
     operator_from_string(operator::String; lookup=PAULIS)
 

--- a/src/quantum_object_utils.jl
+++ b/src/quantum_object_utils.jl
@@ -15,6 +15,7 @@ using ..Gates
 using LinearAlgebra
 using TestItems
 
+function QobjEvo end
 
 @doc raw"""
     operator_from_string(operator::String; lookup=PAULIS)

--- a/test/test_qobjevo.jl
+++ b/test/test_qobjevo.jl
@@ -1,8 +1,10 @@
 @testitem "QobjEvo tests" begin
+    using QuantumCollocation: UnitarySmoothPulseProblem, UnitaryInfidelityObjective, UnitaryIntegrator
+    using DirectTrajOpt: DirectTrajOptProblem
     using QuantumToolbox
-    using QuantumToolbox:  Qobj, length, size, basis, destroy, sigmaz, sigmax, expect, mesolve, sesolve
+    using QuantumToolbox: QobjEvo, basis, destroy, sigmaz, sigmax, expect, mesolve, sesolve
     using PiccoloQuantumObjects
-    using PiccoloQuantumObjects: get_drift, get_drives
+    using PiccoloQuantumObjects: get_drift, get_drives, QuantumSystem
     using NamedTrajectories
     using NamedTrajectories: get_times
     using Interpolations
@@ -167,7 +169,7 @@
         Δt_se = 0.05
         times_se_expected = collect(0.0:Δt_se:(T_se-1)*Δt_se)
         a_values_se = reshape(sin.(times_se_expected * π / times_se_expected[end]), 1, :)
-        prob_se = UnitarySmoothPulseProblem(sys_se, Piccolo.GATES.X, T_se, Δt_se; a_bound=1.0, dda_bound=1.0)
+        prob_se = UnitarySmoothPulseProblem(sys_se, GATES.X, T_se, Δt_se; a_bound=1.0, dda_bound=1.0)
         solve!(prob_se; max_iter=10)
         traj_se = prob_se.trajectory
         a_idx_range_se = traj_se.components.a

--- a/test/test_qobjevo.jl
+++ b/test/test_qobjevo.jl
@@ -1,10 +1,8 @@
 @testitem "QobjEvo tests" begin
-    using QuantumCollocation: UnitarySmoothPulseProblem, UnitaryInfidelityObjective, UnitaryIntegrator
-    using DirectTrajOpt: DirectTrajOptProblem
     using QuantumToolbox
     using QuantumToolbox: QobjEvo, basis, destroy, sigmaz, sigmax, expect, mesolve, sesolve
     using PiccoloQuantumObjects
-    using PiccoloQuantumObjects: get_drift, get_drives, QuantumSystem
+    using PiccoloQuantumObjects: get_drift, get_drives, QuantumSystem, OpenQuantumSystem
     using NamedTrajectories
     using NamedTrajectories: get_times
     using LinearAlgebra
@@ -67,47 +65,42 @@
         @test isapprox(norm(sol.states[end]), 1.0, atol=1e-4)
     end
 
-    @testset "Quantum System: Single drive, basic amplitudes" begin
-        H_drift = 0.5 * PAULIS.Z
-        H_drives = [PAULIS.X]
+    @testset "QuantumSystem: Single drive, basic amplitudes" begin
+        H_drift = 0.5 * PAULIS[:Z]
+        H_drives = [PAULIS[:X]]
         sys = QuantumSystem(H_drift, H_drives)
         T = 5
         Δt = 0.1
         a_vals = [0.1 0.2 0.3 0.4 0.5]
-        prob = UnitarySmoothPulseProblem(sys, GATES.X, T, Δt; a_bound=1.0, dda_bound=1.0)
-        solve!(prob; max_iter=1)
-        traj = prob.trajectory
-        a_range = traj.components.a
-        traj.data[a_range, :] = a_vals
-        H_evo = QobjEvo(sys, traj)
-        times = get_times(traj)
-        @test isapprox_qobj(H_evo(times[1]), Qobj(H_drift + a_vals[1] * H_drives[1]))
-        @test isapprox_qobj(H_evo(times[3]), Qobj(H_drift + a_vals[3] * H_drives[1]))
-        t_mid = times[2] - 0.01*Δt
-        @test isapprox_qobj(H_evo(t_mid), Qobj(H_drift + a_vals[1] * H_drives[1]))
-    end
+        traj = NamedTrajectory(
+            (a = a_vals, Δt = fill(Δt, 1, T)),
+            timestep=:Δt,
+            controls=:a
+         )
+         H_evo = QobjEvo(sys, traj)
+         times = get_times(traj)
+         @test isapprox_qobj(H_evo(times[1]), Qobj(H_drift + a_vals[1,1] * H_drives[1]))
+         @test isapprox_qobj(H_evo(times[3]), Qobj(H_drift + a_vals[1,3] * H_drives[1]))
+         t_mid = times[2] - 0.01*Δt
+         @test isapprox_qobj(H_evo(t_mid), Qobj(H_drift + a_vals[1,1] * H_drives[1]))
+     end
 
-    @testset "Quantum System: sesolve with DirectTrajOptProblem for state transfer" begin
-        H_drift = 0.05 * PAULIS.Z
-        H_drives = [PAULIS.X]
+    @testset "QuantumSystem: State transfer with sesolve" begin
+        H_drift = 0.05 * PAULIS[:Z]
+        H_drives = [PAULIS[:X]]
         sys = QuantumSystem(H_drift, H_drives)
-        dim = size(H_drift, 1)
         T = 50
         Δt = 0.1
-        prob = UnitarySmoothPulseProblem(sys, GATES.X, T, Δt; a_bound=1.0, dda_bound=1.0)
-        solve!(prob; max_iter=1)
-        traj = prob.trajectory
-        t_values = range(0, (T-1)*Δt; step=Δt)
-        amps = sin.(2π .* t_values ./ (T*Δt))'
-        traj.data[traj.components.a, :] = amps
-        unitary_sym = first(s for s in keys(traj.components) if startswith(string(s), "Ũ"))
-        obj = UnitaryInfidelityObjective(GATES.X, unitary_sym, traj)
-        integrator = UnitaryIntegrator(sys, traj, unitary_sym, :a)
-        direct_prob = DirectTrajOptProblem(traj, obj, integrator)
-        solve!(direct_prob; max_iter=1)
-        H_evo = QobjEvo(sys, direct_prob.trajectory)
-        times = get_times(direct_prob.trajectory)
-        ψ0 = basis(dim, 0)
+        times = range(0, (T-1)*Δt, length=T)
+        amps = zeros(1, T)
+        amps[1,:] = sin.(2π .* times ./ (T*Δt))
+        traj = NamedTrajectory(
+            (a = amps, Δt = fill(Δt, 1, T)),
+            timestep=:Δt,
+             controls=:a
+        )
+        H_evo = QobjEvo(sys, traj)
+        ψ0 = basis(2, 0)
         sol = sesolve(H_evo, ψ0, times; progress_bar=Val(false), saveat=times)
         @test length(sol.states) == length(times)
         @test isapprox(norm(sol.states[1]), 1.0, atol=1e-6)
@@ -117,18 +110,20 @@
         @test !isapprox(z0, zf, atol=1e-3) || (length(times) <= 1)
     end
 
-    @testset "Quantum System: mesolve with dissipative dynamics" begin
-        H_drift = 0.1 * PAULIS.Z
-        H_drives = [PAULIS.X]
+    @testset "QuantumSystem: mesolve with dissipative dynamics" begin
+        H_drift = 0.1 * PAULIS[:Z]
+        H_drives = [PAULIS[:X]]
         sys = QuantumSystem(H_drift, H_drives)
         T = 20
         Δt = 0.1
-        times = range(0.0, (T-1)*Δt; step=Δt)
-        amps = sin.(times * 2π / times[end] * 0.5)'
-        prob = UnitarySmoothPulseProblem(sys, GATES.X, T, Δt; a_bound=1.0, dda_bound=1.0)
-        solve!(prob; max_iter=10)
-        traj = prob.trajectory
-        traj.data[traj.components.a, :] = amps
+        times = range(0.0, (T-1)*Δt, length=T)
+        amps = zeros(1, T)
+        amps[1,:] = sin.(times * 2π / times[end] * 0.5)
+        traj = NamedTrajectory(
+            (a = amps, Δt = fill(Δt, 1, T)),
+            timestep=:Δt,
+            controls=:a
+        )
         H_evo = QobjEvo(sys, traj)
         ψ0 = basis(2, 0)
         c_ops = [sqrt(0.1) * destroy(2)]
@@ -138,75 +133,76 @@
         @test size(sol.expect) == (length(e_ops), length(times))
         @test isapprox(real(sol.expect[1, 1]), real(expect(sigmaz(), ψ0)))
         @test isapprox(real(sol.expect[2, 1]), real(expect(sigmax(), ψ0)))
-        @test !isapprox(real(sol.expect[1, 1]), real(sol.expect[1, end]), atol=1e-3) || (length(times) <= 1)
-        @test !isapprox(real(sol.expect[2, 1]), real(sol.expect[2, end]), atol=1e-3) || (length(times) <= 1)
+        @test !isapprox(real(sol.expect[1, 1]), real(sol.expect[1, end]), atol=1e-3)
+        @test !isapprox(real(sol.expect[2, 1]), real(sol.expect[2, end]), atol=1e-3)
         for state in sol.states
             @test isapprox(norm(state), 1.0, atol=1e-6)
         end
     end
 
-    @testset "Quantum System: Multiple drives, varying amplitudes" begin
-        H_drift = 0.05 * PAULIS.Z
-        H_drives = [PAULIS.X, PAULIS.Y]
+    @testset "QuantumSystem: Multiple drives, varying amplitudes" begin
+        H_drift = 0.05 * PAULIS[:Z]
+        H_drives = [PAULIS[:X], PAULIS[:Y]]
         sys = QuantumSystem(H_drift, H_drives)
         T = 10
         Δt = 0.2
-        a_vals = vcat(reshape(cos.(collect(0.0:Δt:(T-1)*Δt)), 1, :), reshape(sin.(collect(0.0:Δt:(T-1)*Δt)), 1, :))
-        prob = UnitarySmoothPulseProblem(sys, GATES.Z, T, Δt; a_bound=1.0, dda_bound=1.0)
-        solve!(prob; max_iter=1)
-        traj= prob.trajectory
-        a_idx = traj.components.a
-        traj.data[a_idx, :] = a_vals
+        times = range(0.0, (T-1)*Δt, length=T)
+        a_vals = [cos.(times)'; sin.(times)']
+        traj = NamedTrajectory(
+            (a = a_vals, Δt = fill(Δt, 1, T)),
+            timestep=:Δt,
+            controls=:a
+        )
         H_evo = QobjEvo(sys, traj)
         times = get_times(traj)
-        @test isapprox_qobj(H_evo(times[1]), Qobj(H_drift + a_vals[1, 1] * H_drives[1] + a_vals[2, 1] * H_drives[2]))
-        @test isapprox_qobj(H_evo(times[end]), Qobj(H_drift + a_vals[1, end] * H_drives[1] + a_vals[2, end] * H_drives[2]))
+        @test isapprox_qobj(H_evo(times[1]), Qobj(H_drift + a_vals[1,1] * H_drives[1] + a_vals[2,1] * H_drives[2]))
+        @test isapprox_qobj(H_evo(times[end]), Qobj(H_drift + a_vals[1,end] * H_drives[1] + a_vals[2,end] * H_drives[2]))
         t_interp = (times[5] + times[6]) / 2
-        expected_a1_zoh2 = a_vals[1, 5]
-        expected_a2_zoh2 = a_vals[2, 5]
-        @test isapprox_qobj(H_evo(t_interp), Qobj(H_drift + expected_a1_zoh2 * H_drives[1] + expected_a2_zoh2 * H_drives[2]))
+        @test isapprox_qobj(H_evo(t_interp), Qobj(H_drift + a_vals[1,5] * H_drives[1] + a_vals[2,5] * H_drives[2]))
         t_just_before = times[3] - 1e-10
-        @test isapprox_qobj(H_evo(t_just_before), Qobj(H_drift + a_vals[1, 2] * H_drives[1] + a_vals[2, 2] * H_drives[2]))
+        @test isapprox_qobj(H_evo(t_just_before), Qobj(H_drift + a_vals[1,2] * H_drives[1] + a_vals[2,2] * H_drives[2]))
     end
 
-    @testset "Quantum System: Drives-only QuantumSystem (no drift)" begin
+    @testset "QuantumSystem: Drives-only QuantumSystem (no drift)" begin
         H_drift = zeros(2, 2)
-        H_drives = [PAULIS.X]
+        H_drives = [PAULIS[:X]]
         sys = QuantumSystem(H_drift, H_drives)
         T = 5
         Δt = 0.1
-        times = collect(0.0:Δt:(T-1)*Δt)
-        a_vals = reshape(ones(length(times)), 1, :)
-        prob = UnitarySmoothPulseProblem(sys, GATES.X, T, Δt; a_bound=1.0, dda_bound=1.0)
-        solve!(prob; max_iter=1)
-        traj = prob.trajectory
-        a_idx_range = traj.components.a
-        traj.data[a_idx_range, :] = a_vals
+        times = range(0.0, (T-1)*Δt, length=T)
+        a_vals = ones(1, T)
+        traj = NamedTrajectory(
+            (a = a_vals, Δt = fill(Δt, 1, T)),
+            timestep=:Δt,
+            controls=:a
+        )
         H_evo = QobjEvo(sys, traj)
-        @test isapprox_qobj(H_evo(times[1]), Qobj(a_vals[1, 1] * H_drives[1]))
-        @test isapprox_qobj(H_evo(times[end]), Qobj(a_vals[1, end] * H_drives[1]))
+        @test isapprox_qobj(H_evo(times[1]), Qobj(a_vals[1,1] * H_drives[1]))
+        @test isapprox_qobj(H_evo(times[end]), Qobj(a_vals[1,end] * H_drives[1]))
     end
 
-    @testset "Quantum System: sesolve integration (closed system)" begin
-        H_drift = 0.01 * PAULIS.Z
-        H_drives = [PAULIS.X]
+    @testset "sesolve integration (closed system)" begin
+        H_drift = 0.01 * PAULIS[:Z]
+        H_drives = [PAULIS[:X]]
         sys = QuantumSystem(H_drift, H_drives)
         T = 10
         Δt = 0.05
-        times = collect(0.0:Δt:(T-1)*Δt)
-        a_values = reshape(sin.(times * π / times[end]), 1, :)
-        prob = UnitarySmoothPulseProblem(sys, GATES.X, T, Δt; a_bound=1.0, dda_bound=1.0)
-        solve!(prob; max_iter=10)
-        traj = prob.trajectory
-        a_idx_range = traj.components.a
-        traj.data[a_idx_range, :] = a_values
-        H_evo = QobjEvo(sys, traj)
-        times = get_times(traj)
-        ψ0 = basis(2, 0)
-        sol = sesolve(H_evo, ψ0, times; progress_bar = Val(false), saveat = times)
-        @test length(sol.states) == length(times)
-        @test isapprox(norm(sol.states[1]), 1.0, atol=1e-6)
-        @test isapprox(norm(sol.states[end]), 1.0, atol=1e-6)
-        @test !isapprox(real(expect(QuantumToolbox.sigmaz(), ψ0)), real(expect(QuantumToolbox.sigmaz(), sol.states[end])), atol=1e-3) || (length(times) <= 1)
-    end
+        times = range(0.0, (T-1)*Δt, length=T)
+        a_values = zeros(1, T)
+        a_values[1,:] = sin.(times * π / times[end])
+        traj = NamedTrajectory(
+            (a = a_values, Δt = fill(Δt, 1, T)),
+            timestep=:Δt,
+            controls=:a
+       )
+       H_evo = QobjEvo(sys, traj)
+       ψ0 = basis(2, 0)
+       sol = sesolve(H_evo, ψ0, times; progress_bar=Val(false), saveat=times)
+       @test length(sol.states) == length(times)
+       @test isapprox(norm(sol.states[1]), 1.0, atol=1e-6)
+       @test isapprox(norm(sol.states[end]), 1.0, atol=1e-6)
+       initial_z = real(expect(sigmaz(), ψ0))
+       final_z = real(expect(sigmaz(), sol.states[end]))
+       @test !isapprox(initial_z, final_z, atol=1e-3) || (length(times) <= 1)
+   end
 end

--- a/test/test_qobjevo.jl
+++ b/test/test_qobjevo.jl
@@ -13,40 +13,58 @@
         return qobj1.type == qobj2.type && qobj1.dims == qobj2.dims && isapprox(qobj1.data, qobj2.data; kwargs...)
     end
 
-    @testset "QuantumSystem's QobjEvo Conversion" begin
-        H_drift = 0.5 * PAULIS[:Z]
-        H_drives = [PAULIS[:X]]
-        sys = QuantumSystem(H_drift, H_drives)
-        T = 10
-        Δt = 0.1
-        a_vals = Matrix{Float64}(undef, 1, T)
-        a_vals[1,:] = 0.1 * sin.(range(0, 2π, length=T))
-        traj = NamedTrajectory((a = a_vals, Δt = fill(Δt, 1, T)), timestep=:Δt, controls=:a)
-        H_evo = QobjEvo(sys, traj)
-        @test isapprox_qobj(H_evo(get_times(traj)[1]), Qobj(H_drift + a_vals[1,1] * H_drives[1]))
-        H_drives_multi = [PAULIS[:X], PAULIS[:Y]]
-        sys_multi = QuantumSystem(H_drift, H_drives_multi)
-        a_vals_multi = Matrix{Float64}(undef, 2, T)
-        a_vals_multi[1,:] = 0.1 * sin.(range(0, 2π, length=T))
-        a_vals_multi[2,:] = 0.2 * cos.(range(0, 2π, length=T))
-        traj_multi = NamedTrajectory((a = a_vals_multi, Δt = fill(Δt, 1, T)), timestep=:Δt, controls=:a)
-        H_evo_multi = QobjEvo(sys_multi, traj_multi)
-        @test H_evo_multi isa QobjEvo
-    end
+    @testset "QuantumSystem Time Evolution" begin
+           H_drift = 1.0 * PAULIS[:Z]
+           H_drives = [1.0 * PAULIS[:X], 1.0 * PAULIS[:Y]]
+           sys = QuantumSystem(H_drift, H_drives)
+           T = 100
+           Δt = 0.05
+           times = range(0, (T-1)*Δt, length=T)
+           a_vals = Matrix{Float64}(undef, 2, T)
+           a_vals[1,:] = 1.0 * sin.(2π * times / times[end])
+           a_vals[2,:] = 1.0 * cos.(2π * times / times[end])
+           traj = NamedTrajectory(
+               (a = a_vals, Δt = fill(Δt, 1, T)),
+               timestep=:Δt,
+               controls=:a
+           )
+           H_evo = QobjEvo(sys, traj)
+           ψ0 = basis(2, 0)
+           sol = sesolve(H_evo, ψ0, get_times(traj))
+           @test length(sol.states) == T
+           @test isapprox(norm(ψ0), 1.0, atol=1e-6)
+           @test isapprox(norm(sol.states[end]), 1.0, atol=1e-6)
+           initial_z = expect(sigmaz(), ψ0)
+           final_z = expect(sigmaz(), sol.states[end])
+           z_change = abs(initial_z - final_z)
+           @test z_change > 0.02 || isapprox(z_change, 0.0, atol=0.02)
+       end
 
-    @testset "OpenQuantumSystem's QobjEvo Conversion" begin
+    @testset "OpenQuantumSystem Time Evolution" begin
         H_drift = 0.5 * PAULIS[:Z]
         H_drives = [PAULIS[:X]]
-        diss_ops = [sqrt(0.1)*PAULIS[:Z], sqrt(0.05)*PAULIS[:X]]
+        diss_ops = [sqrt(0.5)*PAULIS[:Z], sqrt(0.25)*PAULIS[:X]]
         sys = OpenQuantumSystem(H_drift, H_drives, diss_ops)
-        T = 10
-        Δt = 0.1
-        a_vals = zeros(1, T)
-        a_vals[1,:] = 0.1 * sin.(range(0, 2π, length=T))
-        traj = NamedTrajectory((a = a_vals, Δt = fill(Δt, 1, T)), timestep=:Δt, controls=:a)
+        T = 100
+        Δt = 0.05
+        times = range(0, (T-1)*Δt, length=T)
+        a_vals = Matrix{Float64}(undef, 1, T)
+        a_vals[1,:] = 0.5 * sin.(3π * times / times[end])
+        traj = NamedTrajectory(
+            (a = a_vals, Δt = fill(Δt, 1, T)),
+            timestep=:Δt,
+            controls=:a
+        )
         H_evo, c_ops = QobjEvo(sys, traj)
-        @test H_evo isa QobjEvo
-        @test all(isapprox_qobj.(c_ops, Qobj.(diss_ops)))
+        ψ0 = basis(2, 0)
+        e_ops = [sigmaz(), sigmax()]
+        sol = mesolve(H_evo, ψ0, get_times(traj), c_ops; e_ops=e_ops, saveat=get_times(traj))
+        @test length(sol.states) == T
+        @test size(sol.expect) == (length(e_ops), T)
+        initial_z = expect(sigmaz(), ψ0)
+        final_z = sol.expect[1,end]
+        @test abs(initial_z - final_z) > 0.2
+        @test isapprox(norm(sol.states[end]), 1.0, atol=1e-4)
     end
 
     @testset "Quantum System: Single drive, basic amplitudes" begin

--- a/test/test_qobjevo.jl
+++ b/test/test_qobjevo.jl
@@ -7,180 +7,152 @@
     using PiccoloQuantumObjects: get_drift, get_drives, QuantumSystem
     using NamedTrajectories
     using NamedTrajectories: get_times
-    using Interpolations
     using LinearAlgebra
 
     function isapprox_qobj(qobj1::Qobj, qobj2::Qobj; kwargs...)
         return qobj1.type == qobj2.type && qobj1.dims == qobj2.dims && isapprox(qobj1.data, qobj2.data; kwargs...)
     end
 
-    @testset "Single drive, simple amplitudes" begin
-        H_drift_test1 = 0.5 * PAULIS.Z
-        H_drives_test1 = [PAULIS.X]
-        sys1 = QuantumSystem(H_drift_test1, H_drives_test1)
-        T1 = 5
-        Δt1 = 0.1
-        a_values1 = [0.1 0.2 0.3 0.4 0.5]
-        prob_test1 = UnitarySmoothPulseProblem(sys1, GATES.X, T1, Δt1; a_bound=1.0, dda_bound=1.0)
-        solve!(prob_test1; max_iter=1)
-        traj1 = prob_test1.trajectory
-        a_idx_range1 = traj1.components.a
-        traj1.data[a_idx_range1, :] = a_values1
-        H_evo1 = QobjEvo(sys1, traj1)
-        times1 = get_times(traj1)
-        @test isapprox_qobj(H_evo1(times1[1]), Qobj(H_drift_test1 + a_values1[1] * H_drives_test1[1]))
-        @test isapprox_qobj(H_evo1(times1[3]), Qobj(H_drift_test1 + a_values1[3] * H_drives_test1[1]))
-        @test isapprox_qobj(H_evo1(times1[end]), Qobj(H_drift_test1 + a_values1[end] * H_drives_test1[1]))
-        t_interp1 = (times1[1] + times1[2]) / 2
-        expected_a_interp1 = (a_values1[1] + a_values1[2]) / 2
-        @test isapprox_qobj(H_evo1(t_interp1), Qobj(H_drift_test1 + expected_a_interp1 * H_drives_test1[1]))
+    @testset "Quantum System: Single drive, basic amplitudes" begin
+        H_drift = 0.5 * PAULIS.Z
+        H_drives = [PAULIS.X]
+        sys = QuantumSystem(H_drift, H_drives)
+        T = 5
+        Δt = 0.1
+        a_vals = [0.1 0.2 0.3 0.4 0.5]
+        prob = UnitarySmoothPulseProblem(sys, GATES.X, T, Δt; a_bound=1.0, dda_bound=1.0)
+        solve!(prob; max_iter=1)
+        traj = prob.trajectory
+        a_range = traj.components.a
+        traj.data[a_range, :] = a_vals
+        H_evo = QobjEvo(sys, traj)
+        times = get_times(traj)
+        @test isapprox_qobj(H_evo(times[1]), Qobj(H_drift + a_vals[1] * H_drives[1]))
+        @test isapprox_qobj(H_evo(times[3]), Qobj(H_drift + a_vals[3] * H_drives[1]))
+        t_mid = times[2] - 0.01*Δt
+        @test isapprox_qobj(H_evo(t_mid), Qobj(H_drift + a_vals[1] * H_drives[1]))
     end
 
-    @testset "sesolve using DirectTrajOptProblem for state transfer" begin
-        H_drift_dt = 0.05 * PAULIS.Z
-        H_drives_dt = [PAULIS.X]
-        sys_dt = QuantumSystem(H_drift_dt, H_drives_dt)
-        dim = size(H_drift_dt, 1)
-        num_drives = length(H_drives_dt)
-        T_intervals = 50
-        Δt_init = 0.1
-        prob_baseline = UnitarySmoothPulseProblem(
-            sys_dt, GATES.X, T_intervals, Δt_init;
-            a_bound=1.0, dda_bound=1.0
-        )
-        solve!(prob_baseline; max_iter=1)
-        traj_dt_base = prob_baseline.trajectory
-        amplitude_values = reshape(
-            sin.(collect(0.0:Δt_init:(T_intervals-1)*Δt_init) * 2π / (T_intervals*Δt_init)),
-            num_drives, :
-        )
-        a_idx_range = traj_dt_base.components.a
-        traj_dt_base.data[a_idx_range, :] = amplitude_values
-        unitary_state_symbol = nothing
-        for s in keys(traj_dt_base.components)
-            if startswith(string(s), "Ũ")
-                unitary_state_symbol = s
-                break
-            end
-        end
-        obj_dt = UnitaryInfidelityObjective(GATES.X, unitary_state_symbol, traj_dt_base)
-        integrator_dt = UnitaryIntegrator(sys_dt, traj_dt_base, unitary_state_symbol, :a)
-        prob_direct = DirectTrajOptProblem(
-            traj_dt_base,
-            obj_dt,
-            integrator_dt
-        )
-        solve!(prob_direct; max_iter=1)
-        optimized_traj_dt = prob_direct.trajectory
-        H_evo_dt = QobjEvo(sys_dt, optimized_traj_dt)
-        times_dt = get_times(optimized_traj_dt)
-        ψ0_dt = basis(dim, 0)
-        sol_dt = sesolve(H_evo_dt, ψ0_dt, times_dt; progress_bar=Val(false), saveat=times_dt)
-        @test length(sol_dt.states) == length(times_dt)
-        @test isapprox(norm(sol_dt.states[1]), 1.0, atol=1e-6)
-        @test isapprox(norm(sol_dt.states[end]), 1.0, atol=1e-6)
-        initial_expect_z_dt = real(expect(sigmaz(), ψ0_dt))
-        final_expect_z_dt = real(expect(sigmaz(), sol_dt.states[end]))
-        @test !isapprox(initial_expect_z_dt, final_expect_z_dt, atol=1e-3) || (length(times_dt) <= 1)
+    @testset "Quantum System: sesolve with DirectTrajOptProblem for state transfer" begin
+        H_drift = 0.05 * PAULIS.Z
+        H_drives = [PAULIS.X]
+        sys = QuantumSystem(H_drift, H_drives)
+        dim = size(H_drift, 1)
+        T = 50
+        Δt = 0.1
+        prob = UnitarySmoothPulseProblem(sys, GATES.X, T, Δt; a_bound=1.0, dda_bound=1.0)
+        solve!(prob; max_iter=1)
+        traj = prob.trajectory
+        t_values = range(0, (T-1)*Δt; step=Δt)
+        amps = sin.(2π .* t_values ./ (T*Δt))'
+        traj.data[traj.components.a, :] = amps
+        unitary_sym = first(s for s in keys(traj.components) if startswith(string(s), "Ũ"))
+        obj = UnitaryInfidelityObjective(GATES.X, unitary_sym, traj)
+        integrator = UnitaryIntegrator(sys, traj, unitary_sym, :a)
+        direct_prob = DirectTrajOptProblem(traj, obj, integrator)
+        solve!(direct_prob; max_iter=1)
+        H_evo = QobjEvo(sys, direct_prob.trajectory)
+        times = get_times(direct_prob.trajectory)
+        ψ0 = basis(dim, 0)
+        sol = sesolve(H_evo, ψ0, times; progress_bar=Val(false), saveat=times)
+        @test length(sol.states) == length(times)
+        @test isapprox(norm(sol.states[1]), 1.0, atol=1e-6)
+        @test isapprox(norm(sol.states[end]), 1.0, atol=1e-6)
+        z0 = real(expect(sigmaz(), ψ0))
+        zf = real(expect(sigmaz(), sol.states[end]))
+        @test !isapprox(z0, zf, atol=1e-3) || (length(times) <= 1)
     end
 
-    @testset "using mesolve" begin
-        H_drift_ms = 0.1 * PAULIS.Z
-        H_drives_ms = [PAULIS.X]
-        sys_ms = QuantumSystem(H_drift_ms, H_drives_ms)
-        T_ms = 20
-        Δt_ms = 0.1
-        times_ms_expected = collect(0.0:Δt_ms:(T_ms-1)*Δt_ms)
-        a_values_ms = reshape(sin.(times_ms_expected * 2π / times_ms_expected[end] * 0.5), 1, :)
-        prob_ms = UnitarySmoothPulseProblem(sys_ms, GATES.X, T_ms, Δt_ms; a_bound=1.0, dda_bound=1.0)
-        solve!(prob_ms; max_iter=10)
-        traj_ms = prob_ms.trajectory
-        a_idx_range_ms = traj_ms.components.a
-        traj_ms.data[a_idx_range_ms, :] = a_values_ms
-        H_evo_ms = QobjEvo(sys_ms, traj_ms)
-        times_ms = get_times(traj_ms)
-        ψ0_ms = basis(2, 0)
-        c_ops_ms = [sqrt(0.1) * destroy(2)]
-        e_ops_ms = [sigmaz(), sigmax()]
-        sol_ms = mesolve(H_evo_ms, ψ0_ms, times_ms, c_ops_ms; e_ops=e_ops_ms, progress_bar = Val(false), saveat = times_ms)
-        @test length(sol_ms.states) == length(times_ms)
-        @test size(sol_ms.expect) == (length(e_ops_ms), length(times_ms))
-        @test isapprox(real(sol_ms.expect[1, 1]), real(expect(sigmaz(), ψ0_ms)))
-        @test isapprox(real(sol_ms.expect[2, 1]), real(expect(sigmax(), ψ0_ms)))
-        initial_expect_z = real(expect(sigmaz(), ψ0_ms))
-        final_expect_z = real(sol_ms.expect[1, end])
-        @test !isapprox(initial_expect_z, final_expect_z, atol=1e-3) || (length(times_ms) <= 1)
-        initial_expect_x = real(expect(sigmax(), ψ0_ms))
-        final_expect_x = real(sol_ms.expect[2, end])
-        @test !isapprox(initial_expect_x, final_expect_x, atol=1e-3) || (length(times_ms) <= 1)
-        for i in 1:length(sol_ms.states)
-            @test isapprox(norm(sol_ms.states[i]), 1.0, atol=1e-6)
+    @testset "Quantum System: mesolve with dissipative dynamics" begin
+        H_drift = 0.1 * PAULIS.Z
+        H_drives = [PAULIS.X]
+        sys = QuantumSystem(H_drift, H_drives)
+        T = 20
+        Δt = 0.1
+        times = range(0.0, (T-1)*Δt; step=Δt)
+        amps = sin.(times * 2π / times[end] * 0.5)'
+        prob = UnitarySmoothPulseProblem(sys, GATES.X, T, Δt; a_bound=1.0, dda_bound=1.0)
+        solve!(prob; max_iter=10)
+        traj = prob.trajectory
+        traj.data[traj.components.a, :] = amps
+        H_evo = QobjEvo(sys, traj)
+        ψ0 = basis(2, 0)
+        c_ops = [sqrt(0.1) * destroy(2)]
+        e_ops = [sigmaz(), sigmax()]
+        sol = mesolve(H_evo, ψ0, times, c_ops; e_ops=e_ops, progress_bar=Val(false), saveat=times)
+        @test length(sol.states) == length(times)
+        @test size(sol.expect) == (length(e_ops), length(times))
+        @test isapprox(real(sol.expect[1, 1]), real(expect(sigmaz(), ψ0)))
+        @test isapprox(real(sol.expect[2, 1]), real(expect(sigmax(), ψ0)))
+        @test !isapprox(real(sol.expect[1, 1]), real(sol.expect[1, end]), atol=1e-3) || (length(times) <= 1)
+        @test !isapprox(real(sol.expect[2, 1]), real(sol.expect[2, end]), atol=1e-3) || (length(times) <= 1)
+        for state in sol.states
+            @test isapprox(norm(state), 1.0, atol=1e-6)
         end
     end
 
-    @testset "Multiple drives, varying amplitudes" begin
-        H_drift_test2 = 0.05 * PAULIS.Z
-        H_drives_test2 = [PAULIS.X, PAULIS.Y]
-        sys2 = QuantumSystem(H_drift_test2, H_drives_test2)
-        T2 = 10
-        Δt2 = 0.2
-        a_values2 = vcat(
-            reshape(cos.(collect(0.0:Δt2:(T2-1)*Δt2)), 1, :),
-            reshape(sin.(collect(0.0:Δt2:(T2-1)*Δt2)), 1, :)
-        )
-        prob_test2 = UnitarySmoothPulseProblem(sys2, GATES.Z, T2, Δt2; a_bound=1.0, dda_bound=1.0)
-        solve!(prob_test2; max_iter=1)
-        traj2 = prob_test2.trajectory
-        a_idx_range2 = traj2.components.a
-        traj2.data[a_idx_range2, :] = a_values2
-        H_evo2 = QobjEvo(sys2, traj2)
-        times2 = get_times(traj2)
-        @test isapprox_qobj(H_evo2(times2[1]), Qobj(H_drift_test2 + a_values2[1, 1] * H_drives_test2[1] + a_values2[2, 1] * H_drives_test2[2]))
-        @test isapprox_qobj(H_evo2(times2[end]),Qobj(H_drift_test2 + a_values2[1, end] * H_drives_test2[1] + a_values2[2, end] * H_drives_test2[2]))
-        t_interp2 = (times2[5] + times2[6]) / 2
-        expected_a1_interp2 = (a_values2[1, 5] + a_values2[1, 6]) / 2
-        expected_a2_interp2 = (a_values2[2, 5] + a_values2[2, 6]) / 2
-        @test isapprox_qobj(H_evo2(t_interp2), Qobj(H_drift_test2 + expected_a1_interp2 * H_drives_test2[1] + expected_a2_interp2 * H_drives_test2[2]))
+    @testset "Quantum System: Multiple drives, varying amplitudes" begin
+        H_drift = 0.05 * PAULIS.Z
+        H_drives = [PAULIS.X, PAULIS.Y]
+        sys = QuantumSystem(H_drift, H_drives)
+        T = 10
+        Δt = 0.2
+        a_vals = vcat(reshape(cos.(collect(0.0:Δt:(T-1)*Δt)), 1, :), reshape(sin.(collect(0.0:Δt:(T-1)*Δt)), 1, :))
+        prob = UnitarySmoothPulseProblem(sys, GATES.Z, T, Δt; a_bound=1.0, dda_bound=1.0)
+        solve!(prob; max_iter=1)
+        traj= prob.trajectory
+        a_idx = traj.components.a
+        traj.data[a_idx, :] = a_vals
+        H_evo = QobjEvo(sys, traj)
+        times = get_times(traj)
+        @test isapprox_qobj(H_evo(times[1]), Qobj(H_drift + a_vals[1, 1] * H_drives[1] + a_vals[2, 1] * H_drives[2]))
+        @test isapprox_qobj(H_evo(times[end]), Qobj(H_drift + a_vals[1, end] * H_drives[1] + a_vals[2, end] * H_drives[2]))
+        t_interp = (times[5] + times[6]) / 2
+        expected_a1_zoh2 = a_vals[1, 5]
+        expected_a2_zoh2 = a_vals[2, 5]
+        @test isapprox_qobj(H_evo(t_interp), Qobj(H_drift + expected_a1_zoh2 * H_drives[1] + expected_a2_zoh2 * H_drives[2]))
+        t_just_before = times[3] - 1e-10
+        @test isapprox_qobj(H_evo(t_just_before), Qobj(H_drift + a_vals[1, 2] * H_drives[1] + a_vals[2, 2] * H_drives[2]))
     end
 
-    @testset "Drives-only QuantumSystem (no drift)" begin
-        H_drift_dr = zeros(2, 2) # No drift
-        H_drives_dr = [PAULIS.X]
-        sys_dr = QuantumSystem(H_drift_dr, H_drives_dr)
-        T_dr = 5
-        Δt_dr = 0.1
-        times_dr = collect(0.0:Δt_dr:(T_dr-1)*Δt_dr)
-        a_values_dr = reshape(ones(length(times_dr)), 1, :)
-        prob_dr = UnitarySmoothPulseProblem(sys_dr, GATES.X, T_dr, Δt_dr; a_bound=1.0, dda_bound=1.0)
-        solve!(prob_dr; max_iter=1)
-        traj_dr = prob_dr.trajectory
-        a_idx_range_dr = traj_dr.components.a
-        traj_dr.data[a_idx_range_dr, :] = a_values_dr
-        H_evo_dr = QobjEvo(sys_dr, traj_dr)
-        @test isapprox_qobj(H_evo_dr(times_dr[1]), Qobj(a_values_dr[1, 1] * H_drives_dr[1]))
-        @test isapprox_qobj(H_evo_dr(times_dr[end]), Qobj(a_values_dr[1, end] * H_drives_dr[1]))
+    @testset "Quantum System: Drives-only QuantumSystem (no drift)" begin
+        H_drift = zeros(2, 2)
+        H_drives = [PAULIS.X]
+        sys = QuantumSystem(H_drift, H_drives)
+        T = 5
+        Δt = 0.1
+        times = collect(0.0:Δt:(T-1)*Δt)
+        a_vals = reshape(ones(length(times)), 1, :)
+        prob = UnitarySmoothPulseProblem(sys, GATES.X, T, Δt; a_bound=1.0, dda_bound=1.0)
+        solve!(prob; max_iter=1)
+        traj = prob.trajectory
+        a_idx_range = traj.components.a
+        traj.data[a_idx_range, :] = a_vals
+        H_evo = QobjEvo(sys, traj)
+        @test isapprox_qobj(H_evo(times[1]), Qobj(a_vals[1, 1] * H_drives[1]))
+        @test isapprox_qobj(H_evo(times[end]), Qobj(a_vals[1, end] * H_drives[1]))
     end
 
-    @testset "sesolve integration (closed system)" begin
-        H_drift_se = 0.01 * PAULIS.Z
-        H_drives_se = [PAULIS.X]
-        sys_se = QuantumSystem(H_drift_se, H_drives_se)
-        T_se = 10
-        Δt_se = 0.05
-        times_se_expected = collect(0.0:Δt_se:(T_se-1)*Δt_se)
-        a_values_se = reshape(sin.(times_se_expected * π / times_se_expected[end]), 1, :)
-        prob_se = UnitarySmoothPulseProblem(sys_se, GATES.X, T_se, Δt_se; a_bound=1.0, dda_bound=1.0)
-        solve!(prob_se; max_iter=10)
-        traj_se = prob_se.trajectory
-        a_idx_range_se = traj_se.components.a
-        traj_se.data[a_idx_range_se, :] = a_values_se
-        H_evo_se = QobjEvo(sys_se, traj_se)
-        times_se = get_times(traj_se)
-        ψ0_se = basis(2, 0)
-        sol_se = sesolve(H_evo_se, ψ0_se, times_se; progress_bar = Val(false), saveat = times_se)
-        @test length(sol_se.states) == length(times_se)
-        @test isapprox(norm(sol_se.states[1]), 1.0, atol=1e-6)
-        @test isapprox(norm(sol_se.states[end]), 1.0, atol=1e-6)
-        @test !isapprox(real(expect(QuantumToolbox.sigmaz(), ψ0_se)), real(expect(QuantumToolbox.sigmaz(), sol_se.states[end])), atol=1e-3) || (length(times_se) <= 1)
+    @testset "Quantum System: sesolve integration (closed system)" begin
+        H_drift = 0.01 * PAULIS.Z
+        H_drives = [PAULIS.X]
+        sys = QuantumSystem(H_drift, H_drives)
+        T = 10
+        Δt = 0.05
+        times = collect(0.0:Δt:(T-1)*Δt)
+        a_values = reshape(sin.(times * π / times[end]), 1, :)
+        prob = UnitarySmoothPulseProblem(sys, GATES.X, T, Δt; a_bound=1.0, dda_bound=1.0)
+        solve!(prob; max_iter=10)
+        traj = prob.trajectory
+        a_idx_range = traj.components.a
+        traj.data[a_idx_range, :] = a_values
+        H_evo = QobjEvo(sys, traj)
+        times = get_times(traj)
+        ψ0 = basis(2, 0)
+        sol = sesolve(H_evo, ψ0, times; progress_bar = Val(false), saveat = times)
+        @test length(sol.states) == length(times)
+        @test isapprox(norm(sol.states[1]), 1.0, atol=1e-6)
+        @test isapprox(norm(sol.states[end]), 1.0, atol=1e-6)
+        @test !isapprox(real(expect(QuantumToolbox.sigmaz(), ψ0)), real(expect(QuantumToolbox.sigmaz(), sol.states[end])), atol=1e-3) || (length(times) <= 1)
     end
 end

--- a/test/test_qobjevo.jl
+++ b/test/test_qobjevo.jl
@@ -12,31 +12,31 @@
     end
 
     @testset "QuantumSystem Time Evolution" begin
-           H_drift = 1.0 * PAULIS[:Z]
-           H_drives = [1.0 * PAULIS[:X], 1.0 * PAULIS[:Y]]
-           sys = QuantumSystem(H_drift, H_drives)
-           T = 100
-           Δt = 0.05
-           times = range(0, (T-1)*Δt, length=T)
-           a_vals = Matrix{Float64}(undef, 2, T)
-           a_vals[1,:] = 1.0 * sin.(2π * times / times[end])
-           a_vals[2,:] = 1.0 * cos.(2π * times / times[end])
-           traj = NamedTrajectory(
-               (a = a_vals, Δt = fill(Δt, 1, T)),
-               timestep=:Δt,
-               controls=:a
-           )
-           H_evo = QobjEvo(sys, traj)
-           ψ0 = basis(2, 0)
-           sol = sesolve(H_evo, ψ0, get_times(traj))
-           @test length(sol.states) == T
-           @test isapprox(norm(ψ0), 1.0, atol=1e-6)
-           @test isapprox(norm(sol.states[end]), 1.0, atol=1e-6)
-           initial_z = expect(sigmaz(), ψ0)
-           final_z = expect(sigmaz(), sol.states[end])
-           z_change = abs(initial_z - final_z)
-           @test z_change > 0.02 || isapprox(z_change, 0.0, atol=0.02)
-       end
+        H_drift = 1.0 * PAULIS[:Z]
+        H_drives = [1.0 * PAULIS[:X], 1.0 * PAULIS[:Y]]
+        sys = QuantumSystem(H_drift, H_drives)
+        T = 100
+        Δt = 0.05
+        times = range(0, (T-1)*Δt, length=T)
+        a_vals = Matrix{Float64}(undef, 2, T)
+        a_vals[1,:] = 1.0 * sin.(2π * times / times[end])
+        a_vals[2,:] = 1.0 * cos.(2π * times / times[end])
+        traj = NamedTrajectory(
+            (a = a_vals, Δt = fill(Δt, 1, T)),
+            timestep=:Δt,
+            controls=:a
+        )
+        H_evo = QobjEvo(sys, traj)
+        ψ0 = basis(2, 0)
+        sol = sesolve(H_evo, ψ0, get_times(traj))
+        @test length(sol.states) == T
+        @test isapprox(norm(ψ0), 1.0, atol=1e-6)
+        @test isapprox(norm(sol.states[end]), 1.0, atol=1e-6)
+        initial_z = expect(sigmaz(), ψ0)
+        final_z = expect(sigmaz(), sol.states[end])
+        z_change = abs(initial_z - final_z)
+        @test z_change > 0.02 || isapprox(z_change, 0.0, atol=0.02)
+    end
 
     @testset "OpenQuantumSystem Time Evolution" begin
         H_drift = 0.5 * PAULIS[:Z]
@@ -76,14 +76,14 @@
             (a = a_vals, Δt = fill(Δt, 1, T)),
             timestep=:Δt,
             controls=:a
-         )
-         H_evo = QobjEvo(sys, traj)
-         times = get_times(traj)
-         @test isapprox_qobj(H_evo(times[1]), Qobj(H_drift + a_vals[1,1] * H_drives[1]))
-         @test isapprox_qobj(H_evo(times[3]), Qobj(H_drift + a_vals[1,3] * H_drives[1]))
-         t_mid = times[2] - 0.01*Δt
-         @test isapprox_qobj(H_evo(t_mid), Qobj(H_drift + a_vals[1,1] * H_drives[1]))
-     end
+        )
+        H_evo = QobjEvo(sys, traj)
+        times = get_times(traj)
+        @test isapprox_qobj(H_evo(times[1]), Qobj(H_drift + a_vals[1,1] * H_drives[1]))
+        @test isapprox_qobj(H_evo(times[3]), Qobj(H_drift + a_vals[1,3] * H_drives[1]))
+        t_mid = times[2] - 0.01*Δt
+        @test isapprox_qobj(H_evo(t_mid), Qobj(H_drift + a_vals[1,1] * H_drives[1]))
+    end
 
     @testset "QuantumSystem: State transfer with sesolve" begin
         H_drift = 0.05 * PAULIS[:Z]
@@ -181,7 +181,7 @@
         @test isapprox_qobj(H_evo(times[end]), Qobj(a_vals[1,end] * H_drives[1]))
     end
 
-    @testset "sesolve integration (closed system)" begin
+    @testset "QuantumSystem: sesolve integration" begin
         H_drift = 0.01 * PAULIS[:Z]
         H_drives = [PAULIS[:X]]
         sys = QuantumSystem(H_drift, H_drives)

--- a/test/test_qobjevo.jl
+++ b/test/test_qobjevo.jl
@@ -13,6 +13,42 @@
         return qobj1.type == qobj2.type && qobj1.dims == qobj2.dims && isapprox(qobj1.data, qobj2.data; kwargs...)
     end
 
+    @testset "QuantumSystem's QobjEvo Conversion" begin
+        H_drift = 0.5 * PAULIS[:Z]
+        H_drives = [PAULIS[:X]]
+        sys = QuantumSystem(H_drift, H_drives)
+        T = 10
+        Δt = 0.1
+        a_vals = Matrix{Float64}(undef, 1, T)
+        a_vals[1,:] = 0.1 * sin.(range(0, 2π, length=T))
+        traj = NamedTrajectory((a = a_vals, Δt = fill(Δt, 1, T)), timestep=:Δt, controls=:a)
+        H_evo = QobjEvo(sys, traj)
+        @test isapprox_qobj(H_evo(get_times(traj)[1]), Qobj(H_drift + a_vals[1,1] * H_drives[1]))
+        H_drives_multi = [PAULIS[:X], PAULIS[:Y]]
+        sys_multi = QuantumSystem(H_drift, H_drives_multi)
+        a_vals_multi = Matrix{Float64}(undef, 2, T)
+        a_vals_multi[1,:] = 0.1 * sin.(range(0, 2π, length=T))
+        a_vals_multi[2,:] = 0.2 * cos.(range(0, 2π, length=T))
+        traj_multi = NamedTrajectory((a = a_vals_multi, Δt = fill(Δt, 1, T)), timestep=:Δt, controls=:a)
+        H_evo_multi = QobjEvo(sys_multi, traj_multi)
+        @test H_evo_multi isa QobjEvo
+    end
+
+    @testset "OpenQuantumSystem's QobjEvo Conversion" begin
+        H_drift = 0.5 * PAULIS[:Z]
+        H_drives = [PAULIS[:X]]
+        diss_ops = [sqrt(0.1)*PAULIS[:Z], sqrt(0.05)*PAULIS[:X]]
+        sys = OpenQuantumSystem(H_drift, H_drives, diss_ops)
+        T = 10
+        Δt = 0.1
+        a_vals = zeros(1, T)
+        a_vals[1,:] = 0.1 * sin.(range(0, 2π, length=T))
+        traj = NamedTrajectory((a = a_vals, Δt = fill(Δt, 1, T)), timestep=:Δt, controls=:a)
+        H_evo, c_ops = QobjEvo(sys, traj)
+        @test H_evo isa QobjEvo
+        @test all(isapprox_qobj.(c_ops, Qobj.(diss_ops)))
+    end
+
     @testset "Quantum System: Single drive, basic amplitudes" begin
         H_drift = 0.5 * PAULIS.Z
         H_drives = [PAULIS.X]

--- a/test/test_qobjevo.jl
+++ b/test/test_qobjevo.jl
@@ -1,0 +1,136 @@
+@testitem "QobjEvo tests" begin
+    using QuantumToolbox
+    using QuantumToolbox:  Qobj, length, size, basis, destroy, sigmaz, sigmax, expect, mesolve, sesolve
+    using PiccoloQuantumObjects
+    using PiccoloQuantumObjects: get_drift, get_drives
+    using NamedTrajectories
+    using NamedTrajectories: get_times
+    using Interpolations
+    using LinearAlgebra
+
+    function isapprox_qobj(qobj1::Qobj, qobj2::Qobj; kwargs...)
+        return qobj1.type == qobj2.type && qobj1.dims == qobj2.dims && isapprox(qobj1.data, qobj2.data; kwargs...)
+    end
+
+    @testset "Single drive, simple amplitudes" begin
+        H_drift_test1 = 0.5 * PAULIS.Z
+        H_drives_test1 = [PAULIS.X]
+        sys1 = QuantumSystem(H_drift_test1, H_drives_test1)
+        T1 = 5
+        Δt1 = 0.1
+        a_values1 = [0.1 0.2 0.3 0.4 0.5]
+        prob_test1 = UnitarySmoothPulseProblem(sys1, GATES.X, T1, Δt1; a_bound=1.0, dda_bound=1.0)
+        solve!(prob_test1; max_iter=1)
+        traj1 = prob_test1.trajectory
+        a_idx_range1 = traj1.components.a
+        traj1.data[a_idx_range1, :] = a_values1
+        H_evo1 = QobjEvo(sys1, traj1)
+        times1 = get_times(traj1)
+        @test isapprox_qobj(H_evo1(times1[1]), Qobj(H_drift_test1 + a_values1[1] * H_drives_test1[1]))
+        @test isapprox_qobj(H_evo1(times1[3]), Qobj(H_drift_test1 + a_values1[3] * H_drives_test1[1]))
+        @test isapprox_qobj(H_evo1(times1[end]), Qobj(H_drift_test1 + a_values1[end] * H_drives_test1[1]))
+        t_interp1 = (times1[1] + times1[2]) / 2
+        expected_a_interp1 = (a_values1[1] + a_values1[2]) / 2
+        @test isapprox_qobj(H_evo1(t_interp1), Qobj(H_drift_test1 + expected_a_interp1 * H_drives_test1[1]))
+    end
+
+    @testset "using mesolve" begin
+        H_drift_ms = 0.1 * PAULIS.Z
+        H_drives_ms = [PAULIS.X]
+        sys_ms = QuantumSystem(H_drift_ms, H_drives_ms)
+        T_ms = 20
+        Δt_ms = 0.1
+        times_ms_expected = collect(0.0:Δt_ms:(T_ms-1)*Δt_ms)
+        a_values_ms = reshape(sin.(times_ms_expected * 2π / times_ms_expected[end] * 0.5), 1, :)
+        prob_ms = UnitarySmoothPulseProblem(sys_ms, GATES.X, T_ms, Δt_ms; a_bound=1.0, dda_bound=1.0)
+        solve!(prob_ms; max_iter=10)
+        traj_ms = prob_ms.trajectory
+        a_idx_range_ms = traj_ms.components.a
+        traj_ms.data[a_idx_range_ms, :] = a_values_ms
+        H_evo_ms = QobjEvo(sys_ms, traj_ms)
+        times_ms = get_times(traj_ms)
+        ψ0_ms = basis(2, 0)
+        c_ops_ms = [sqrt(0.1) * destroy(2)]
+        e_ops_ms = [sigmaz(), sigmax()]
+        sol_ms = mesolve(H_evo_ms, ψ0_ms, times_ms, c_ops_ms; e_ops=e_ops_ms, progress_bar = Val(false), saveat = times_ms)
+        @test length(sol_ms.states) == length(times_ms)
+        @test size(sol_ms.expect) == (length(e_ops_ms), length(times_ms))
+        @test isapprox(real(sol_ms.expect[1, 1]), real(expect(sigmaz(), ψ0_ms)))
+        @test isapprox(real(sol_ms.expect[2, 1]), real(expect(sigmax(), ψ0_ms)))
+        initial_expect_z = real(expect(sigmaz(), ψ0_ms))
+        final_expect_z = real(sol_ms.expect[1, end])
+        @test !isapprox(initial_expect_z, final_expect_z, atol=1e-3) || (length(times_ms) <= 1)
+        initial_expect_x = real(expect(sigmax(), ψ0_ms))
+        final_expect_x = real(sol_ms.expect[2, end])
+        @test !isapprox(initial_expect_x, final_expect_x, atol=1e-3) || (length(times_ms) <= 1)
+        for i in 1:length(sol_ms.states)
+            @test isapprox(norm(sol_ms.states[i]), 1.0, atol=1e-6)
+        end
+    end
+
+    @testset "Multiple drives, varying amplitudes" begin
+        H_drift_test2 = 0.05 * PAULIS.Z
+        H_drives_test2 = [PAULIS.X, PAULIS.Y]
+        sys2 = QuantumSystem(H_drift_test2, H_drives_test2)
+        T2 = 10
+        Δt2 = 0.2
+        a_values2 = vcat(
+            reshape(cos.(collect(0.0:Δt2:(T2-1)*Δt2)), 1, :),
+            reshape(sin.(collect(0.0:Δt2:(T2-1)*Δt2)), 1, :)
+        )
+        prob_test2 = UnitarySmoothPulseProblem(sys2, GATES.Z, T2, Δt2; a_bound=1.0, dda_bound=1.0)
+        solve!(prob_test2; max_iter=1)
+        traj2 = prob_test2.trajectory
+        a_idx_range2 = traj2.components.a
+        traj2.data[a_idx_range2, :] = a_values2
+        H_evo2 = QobjEvo(sys2, traj2)
+        times2 = get_times(traj2)
+        @test isapprox_qobj(H_evo2(times2[1]), Qobj(H_drift_test2 + a_values2[1, 1] * H_drives_test2[1] + a_values2[2, 1] * H_drives_test2[2]))
+        @test isapprox_qobj(H_evo2(times2[end]),Qobj(H_drift_test2 + a_values2[1, end] * H_drives_test2[1] + a_values2[2, end] * H_drives_test2[2]))
+        t_interp2 = (times2[5] + times2[6]) / 2
+        expected_a1_interp2 = (a_values2[1, 5] + a_values2[1, 6]) / 2
+        expected_a2_interp2 = (a_values2[2, 5] + a_values2[2, 6]) / 2
+        @test isapprox_qobj(H_evo2(t_interp2), Qobj(H_drift_test2 + expected_a1_interp2 * H_drives_test2[1] + expected_a2_interp2 * H_drives_test2[2]))
+    end
+
+    @testset "Drives-only QuantumSystem (no drift)" begin
+        H_drift_dr = zeros(2, 2) # No drift
+        H_drives_dr = [PAULIS.X]
+        sys_dr = QuantumSystem(H_drift_dr, H_drives_dr)
+        T_dr = 5
+        Δt_dr = 0.1
+        times_dr = collect(0.0:Δt_dr:(T_dr-1)*Δt_dr)
+        a_values_dr = reshape(ones(length(times_dr)), 1, :)
+        prob_dr = UnitarySmoothPulseProblem(sys_dr, GATES.X, T_dr, Δt_dr; a_bound=1.0, dda_bound=1.0)
+        solve!(prob_dr; max_iter=1)
+        traj_dr = prob_dr.trajectory
+        a_idx_range_dr = traj_dr.components.a
+        traj_dr.data[a_idx_range_dr, :] = a_values_dr
+        H_evo_dr = QobjEvo(sys_dr, traj_dr)
+        @test isapprox_qobj(H_evo_dr(times_dr[1]), Qobj(a_values_dr[1, 1] * H_drives_dr[1]))
+        @test isapprox_qobj(H_evo_dr(times_dr[end]), Qobj(a_values_dr[1, end] * H_drives_dr[1]))
+    end
+
+    @testset "sesolve integration (closed system)" begin
+        H_drift_se = 0.01 * PAULIS.Z
+        H_drives_se = [PAULIS.X]
+        sys_se = QuantumSystem(H_drift_se, H_drives_se)
+        T_se = 10
+        Δt_se = 0.05
+        times_se_expected = collect(0.0:Δt_se:(T_se-1)*Δt_se)
+        a_values_se = reshape(sin.(times_se_expected * π / times_se_expected[end]), 1, :)
+        prob_se = UnitarySmoothPulseProblem(sys_se, Piccolo.GATES.X, T_se, Δt_se; a_bound=1.0, dda_bound=1.0)
+        solve!(prob_se; max_iter=10)
+        traj_se = prob_se.trajectory
+        a_idx_range_se = traj_se.components.a
+        traj_se.data[a_idx_range_se, :] = a_values_se
+        H_evo_se = QobjEvo(sys_se, traj_se)
+        times_se = get_times(traj_se)
+        ψ0_se = basis(2, 0)
+        sol_se = sesolve(H_evo_se, ψ0_se, times_se; progress_bar = Val(false), saveat = times_se)
+        @test length(sol_se.states) == length(times_se)
+        @test isapprox(norm(sol_se.states[1]), 1.0, atol=1e-6)
+        @test isapprox(norm(sol_se.states[end]), 1.0, atol=1e-6)
+        @test !isapprox(real(expect(QuantumToolbox.sigmaz(), ψ0_se)), real(expect(QuantumToolbox.sigmaz(), sol_se.states[end])), atol=1e-3) || (length(times_se) <= 1)
+    end
+end


### PR DESCRIPTION
I have built a weak extension for QuantumToolbox and created a QuantumToolbox QObjEvo  that converts a `QuantumSystem` and a `NamedTrajectory` into a `QobjEvo` object for a closed quantum system. I am working on open quantum system object.

Edit: I get version compat errors when installing Piccolo after installing PiccoloQuantumObjects so I am working directly in Piccolo to build and test the approach. I add tests after testing it via Piccolo. Sorry about the CI errors as I didn't run the library due to compat error to see if there was any error. Thank you very much!